### PR TITLE
Use Foundation to resolve macros instead of UIKit.

### DIFF
--- a/JaSON/JaSON.h
+++ b/JaSON/JaSON.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 SwiftBit. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for JaSON.
 FOUNDATION_EXPORT double JaSONVersionNumber;


### PR DESCRIPTION
Carthage build failed saying `UIKit/UIKit.h` was not available. This seems to resolve that problem.
