### PR TITLE
Include key in errors; fix errors for dates

### DIFF
--- a/JaSON/JSON+Extras.swift
+++ b/JaSON/JSON+Extras.swift
@@ -55,11 +55,13 @@ public typealias JSONObjectArray = [JSONObject]
 
 extension NSDate : JSONValueType {
     public static func JSONValue(object: Any) throws -> NSDate {
-        if let dateString = object as? String,
-            date = NSDate.fromISO8601String(dateString) {
-                return date
+        guard let dateString = object as? String else {
+            throw JSONError.TypeMismatch(expected: String.self, actual: object.dynamicType)
         }
-        throw JSONError.TypeMismatch(expected: String.self, actual: object.dynamicType)
+        guard let date = NSDate.fromISO8601String(dateString) else {
+            throw JSONError.TypeMismatch(expected: "ISO8601 date string", actual: dateString)
+        }
+        return date
     }
 }
 

--- a/JaSONTests/JaSONTests.swift
+++ b/JaSONTests/JaSONTests.swift
@@ -51,7 +51,7 @@ class JaSONTests: XCTestCase {
             catch {
                 let jsonError = error as! JSONError
                 expectation.fulfill()
-                guard case JSONError.TypeMismatch = jsonError else {
+                guard case JSONError.TypeMismatchWithKey = jsonError else {
                     XCTFail("shouldn't get here")
                     return
                 }
@@ -115,7 +115,7 @@ class JaSONTests: XCTestCase {
             let _:Int = try object.JSONValueForKey("str")
         }
         catch {
-            if case JSONError.TypeMismatch = error {
+            if case JSONError.TypeMismatchWithKey = error {
                 expectation.fulfill()
             }
         }


### PR DESCRIPTION
With this change, JSON extraction errors will include the key to more easily identify the problem. Also, date parsing errors are more meaningful. 
